### PR TITLE
Use importlib (from the standard library) instead of the buildin __import__

### DIFF
--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -6,6 +6,7 @@ import os
 import lupa
 import json
 import mwparserfromhell
+import importlib
 from time import sleep
 
 from . import en
@@ -128,7 +129,7 @@ def is_citation_template_name(template_name, lang='en'):
     template_name = template_name.strip()
     template_name = template_name[0].upper()+template_name[1:]
 
-    lang_module = __import__(lang)
+    lang_module = importlib.import_module('.' + lang, package='wikiciteparser')
     if template_name in lang_module.citation_template_names:
         return template_name
 


### PR DESCRIPTION
Hi,

sorry for the flood of pull requests. This is a follow-up from PR https://github.com/dissemin/wikiciteparser/pull/3.

I am changing the dynamic module loading to:

``` python
    lang_module = importlib.import_module('.' + lang, package='wikiciteparser')
```

using the module `importlib` from the Python standard library (see [docs](https://docs.python.org/2/library/importlib.html)). 

It seems cleaner and more robust than the previous solution (which I am not 100% sure was working, by the way).

(EDIT: fixed commit message)
