### PR TITLE
python3 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ language: python
 
 python:
   - 2.7
+  - 3.6
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Let's parse the reference section of [this article](https://en.wikipedia.org/wik
     wikicode = mwparserfromhell.parse(mwtext)
     for tpl in wikicode.filter_templates():
        parsed = parse_citation_template(tpl)
-       print parsed
+       print(parsed)
 
 Here is what you get:
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ article <https://en.wikipedia.org/wiki/Joachim_Lambek>`__::
     wikicode = mwparserfromhell.parse(mwtext)
     for tpl in wikicode.filter_templates():
        parsed = parse_citation_template(tpl)
-       print parsed
+       print(parsed)
 
 Here is what you get::
 

--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -143,7 +143,7 @@ def parse_citation_template(template, lang='en'):
     :returns: a dict representing the template, or None if the template
         provided does not represent a citation.
     """
-    name = unicode(template.name)
+    name = str(template.name)
     if not is_citation_template_name(name, lang):
         return
     return parse_citation_dict(params_to_dict(template.params),

--- a/wikiciteparser/tests.py
+++ b/wikiciteparser/tests.py
@@ -148,7 +148,7 @@ class ParsingTests(unittest.TestCase):
         wikicode = mwparserfromhell.parse(mwtext)
         for tpl in wikicode.filter_templates():
             parsed = parse_citation_template(tpl, 'en')
-            print parsed
+            print(parsed)
             # All templates in this example are citation templates
             self.assertIsInstance(parsed, dict)
 


### PR DESCRIPTION
Unicode is now natively supported in python3 in the form of str(). This PR breaks compatibility with python2 but since it is now officially deprecated I think there's no point in keeping this compatible.

This also introduced some other problems and not it breaks `test_vauthors`, which I haven't figured out how to solve.