### PR TITLE
Parsing improvements: CitationClass, AccessDate

### DIFF
--- a/wikiciteparser/cs1.lua
+++ b/wikiciteparser/cs1.lua
@@ -4954,10 +4954,12 @@ Date validation supporting code is in Module:Citation/CS1/Date_validation
         ['Edition'] = Edition,
         ['PublisherName'] = PublisherName,
         ['URL'] = first_set ({ChapterURL, URL}, 2),
+        ['AccessDate'] = AccessDate,
         ['Format'] = Format,
         ['Authors'] = coins_author,
         ['ID_list'] = ID_list,
         ['RawPage'] = this_page.prefixedText,
+        ['CitationClass'] = config.CitationClass,
     }; -- , config.CitationClass);
 
 end

--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -93,6 +93,10 @@ def parse_citation_dict(arguments, template_name='citation'):
     :returns: a dictionary used as internal representation in wikipedia for rendering and export to other formats
     """
     arguments['_tpl'] = template_name
+    citation_class = template_name.strip().replace('Cite ', '').replace(' ', '-')
+    if citation_class == "Citation":
+        citation_class = "citation"
+    arguments['CitationClass'] = citation_class
     lua_table = lua.table_from(arguments)
     lua_result = lua.eval(luacode)(lua_table,
             ustring_match,

--- a/wikiciteparser/tests.py
+++ b/wikiciteparser/tests.py
@@ -147,10 +147,29 @@ class ParsingTests(unittest.TestCase):
         """
         wikicode = mwparserfromhell.parse(mwtext)
         for tpl in wikicode.filter_templates():
-            parsed = parse_citation_template(tpl, 'en')
+            parsed = parse_citation_template(tpl, lang='en')
             print(parsed)
             # All templates in this example are citation templates
             self.assertIsInstance(parsed, dict)
+            last = parsed
+
+        self.assertEqual(last, {
+            "Authors": [
+                {'first': 'Joachim', 'last': 'Lambek', 'link': 'Joachim Lambek'},
+            ],
+            "Date": "1979",
+            "Pages": "221-234",
+            "Title": "A mathematician looks at Latin conjugation",
+            "Periodical": "Theoretical Linguistics",
+            "Volume": "6",
+            "Issue": "2",
+            "ID_list": {
+                "DOI": "10.1515/thli.1979.6.1-3.221",
+                "ISSN": "0301-4428",
+                "MR": "589163",
+            },
+            "CitationClass": "citation",
+        })
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Passes through the 'AccessDate' field and the 'CitationClass' meta-field in the returned dict.

Also supplies a value for 'CitationClass'. I was surprised this wasn't happening already, and seems to have impacted which fields are actually parsed/returned. Added a bit of test coverage to ensure that expected fields are returned; 'Volume' and 'Issue' were not being returned without the 'CitationClass' config.