### PR TITLE
backport Harshdeep1996 changes; refactor template name handling

### DIFF
--- a/wikiciteparser/en/__init__.py
+++ b/wikiciteparser/en/__init__.py
@@ -26,6 +26,18 @@ citation_template_names = set([
     'Cite thesis',
     'Cite web',
     'Cite arXiv',
+    'London Gazette',
+    'Harvnb',
+    'Harvard citation no brackets',
+    'NRISref',
+    'Cite gnis',
+    'GNIS',
+    'GEOnet3',
+    'Timatic Visa Policy',
+    'Soccerbase season',
+    'Cite sports-reference',
+    'NHLE',
+    'National Heritage List for England'
     # TODO more could be added,
     # see https://en.wikipedia.org/wiki/
     #    Category:Citation_Style_1_specific-source_templates

--- a/wikiciteparser/en/__init__.py
+++ b/wikiciteparser/en/__init__.py
@@ -1,44 +1,45 @@
 # -*- encoding: utf-8 -*-
 
 # taken from https://en.wikipedia.org/wiki/Help:Citation_Style_1
-citation_template_names = set([
-    'Citation',
-    'Cite AV media',
-    'Cite AV media notes',
-    'Cite book',
-    'Cite conference',
-    'Cite DVD notes',
-    'Cite encyclopedia',
-    'Cite episode',
-    'Cite interview',
-    'Cite journal',
-    'Cite mailing list',
-    'Cite map',
-    'Cite news',
-    'Cite newsgroup',
-    'Cite podcast',
-    'Cite press release',
-    'Cite report',
-    'Cite serial',
-    'Cite sign',
-    'Cite speech',
-    'Cite techreport',
-    'Cite thesis',
-    'Cite web',
-    'Cite arXiv',
-    'London Gazette',
-    'Harvnb',
-    'Harvard citation no brackets',
-    'NRISref',
-    'Cite gnis',
-    'GNIS',
-    'GEOnet3',
-    'Timatic Visa Policy',
-    'Soccerbase season',
-    'Cite sports-reference',
-    'NHLE',
-    'National Heritage List for England'
-    # TODO more could be added,
-    # see https://en.wikipedia.org/wiki/
-    #    Category:Citation_Style_1_specific-source_templates
-    ])
+# key: normalized wiki template name
+# value: cs1.lua citation class
+citation_template_classes = {
+    'Citation': 'citation',
+    'Cite AV media': 'AV-media',
+    'Cite AV media notes': 'AV-media-notes',
+    'Cite book': 'book',
+    'Cite conference': 'conference',
+    'Cite DVD notes': 'DVD-notes',
+    'Cite encyclopedia': 'encyclopedia',
+    'Cite episode': 'episode',
+    'Cite interview': 'interview',
+    'Cite journal': 'journal',
+    'Cite mailing list': 'mailinglist',  # not mailing-list
+    'Cite map': 'map',
+    'Cite news': 'news',
+    'Cite newsgroup': 'newsgroup',
+    'Cite podcast': 'podcast',
+    'Cite press release': 'pressrelease',  # not press-release
+    'Cite report': 'report',
+    'Cite serial': 'serial',
+    'Cite sign': 'sign',
+    'Cite speech': 'speech',
+    'Cite techreport': 'techreport',
+    'Cite thesis': 'thesis',
+    'Cite web': 'web',
+    'Cite arXiv': 'arxiv',
+    'Cite gnis': 'gnis',
+    'Cite sports-reference': 'sports-reference',
+    'London Gazette': 'gazette',
+    'Harvnb': 'harvnb',
+    'Harvard citation no brackets': 'harvnb',
+    'NRISref': 'nrisref',
+    'GNIS': 'gnis',
+    'GEOnet3': 'geonet3',
+    'Timatic Visa Policy': 'policy',
+    'Soccerbase season': 'season',
+    'NHLE': 'nhle',
+    'National Heritage List for England': 'england',
+}
+# NOTE: more could be added from:
+# https://en.wikipedia.org/wiki/Category:Citation_Style_1_specific-source_templates

--- a/wikiciteparser/it/__init__.py
+++ b/wikiciteparser/it/__init__.py
@@ -1,9 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-# taken from https://en.wikipedia.org/wiki/Help:Citation_Style_1
-citation_template_names = set([
-    'Cita pubblicazione',
-    # TODO more could be added,
-    # see https://en.wikipedia.org/wiki/
-    #    Category:Citation_Style_1_specific-source_templates
-    ])
+# key: normalized wiki template name
+# value: cs1.lua citation class
+citation_template_classes = {
+    'Cita pubblicazione': 'pubblicazione',
+}

--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -102,6 +102,8 @@ def parse_citation_dict(arguments, template_name='citation'):
     citation_class = template_name.strip().replace('Cite ', '').replace(' ', '-')
     if citation_class == "Citation":
         citation_class = "citation"
+    if template_name in ['Gazette', 'Harvnb', 'NRISref', 'GNIS', 'GEOnet3', 'Policy', 'NHLE', 'England']:
+        template_name = template_name.lower()
     arguments['CitationClass'] = citation_class
     lua_table = lua.table_from(arguments)
     lua_result = lua.eval(luacode)(

--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -14,15 +14,15 @@ with open(luafilepath, 'r') as f:
 
 # MediaWiki utilities simulated by Python wrappers
 def lua_to_python_re(regex):
-    rx = re.sub('%a', '[a-zA-Z]', regex)  # letters
-    rx = re.sub('%c', '[\x7f\x80]', regex)  # control chars
-    rx = re.sub('%d', '[0-9]', rx)  # digits
-    rx = re.sub('%l', '[a-z]', rx)  # lowercase letters
-    rx = re.sub('%p', '\\\\p{P}', rx)  # punctuation chars
-    rx = re.sub('%s', '\\\\s', rx)  # space chars
-    rx = re.sub('%u', '[A-Z]', rx)  # uppercase chars
-    rx = re.sub('%w', '\\\\w', rx)  # alphanumeric chars
-    rx = re.sub('%x', '[0-9A-F]', rx)  # hexa chars
+    rx = re.sub('%a', r'[a-zA-Z]', regex) # letters
+    rx = re.sub('%c', '[\x7f\x80]', regex) # control chars
+    rx = re.sub('%d', r'[0-9]', rx) # digits
+    rx = re.sub('%l', r'[a-z]', rx) # lowercase letters
+    rx = re.sub('%p', r'\\p{P}', rx) # punctuation chars
+    rx = re.sub('%s', r'\\s', rx) # space chars
+    rx = re.sub('%u', r'[A-Z]', rx) # uppercase chars
+    rx = re.sub('%w', r'\\w', rx) # alphanumeric chars
+    rx = re.sub('%x', r'[0-9A-F]', rx) # hexa chars
     return rx
 
 


### PR DESCRIPTION
These are mostly a handful of small backports from this vendored copy of the library: https://github.com/Harshdeep1996/cite-classifications-wiki/tree/master/libraries/wikiciteparser

Plus a refactor of how template names are checked and transformed into citation class names.

This PR is marked as "Draft" until I can test against a bulk dump.