### PR TITLE
Add "encoding='utf8'"

### DIFF
--- a/wikiciteparser/parser.py
+++ b/wikiciteparser/parser.py
@@ -8,7 +8,7 @@ import importlib
 lua = lupa.LuaRuntime()
 luacode = ''
 luafilepath = os.path.join(os.path.dirname(__file__), 'cs1.lua')
-with open(luafilepath, 'r') as f:
+with open(luafilepath, 'r', encoding='utf8') as f:
     luacode = f.read()
 
 


### PR DESCRIPTION
I added `encoding='utf8'` to `open(luafilepath, 'r')` in parser.py because on my machine (Windows 11, Python 3.13.1), because if I don't include that segment of code, I get this error when I import the library:

```
Traceback (most recent call last):
  File "C:\code\blablabla\main.py", line 3, in <module>
    from wikiciteparser.parser import parse_citation_template
  File "C:\code\blablabla\.venv\Lib\site-packages\wikiciteparser\parser.py", line 12, in <module>
    luacode = f.read()
  File "C:\Users\name\AppData\Local\Programs\Python\Python313\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 170990: character maps to <undefined>
```